### PR TITLE
Toolchain fix building

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,6 +1,8 @@
-CC = riscv64-elf-gcc
-LD = riscv64-elf-ld
-AS = riscv64-elf-as
+ARCH = riscv64
+TOOLCHAIN_PREFIX = ${HOME}/opt/cross/bin/
+CC = $(TOOLCHAIN_PREFIX)/riscv64-elf-gcc
+LD = $(TOOLCHAIN_PREFIX)/riscv64-elf-ld
+AS = $(TOOLCHAIN_PREFIX)/riscv64-elf-as
 QEMU = qemu-system-riscv64
 
 CFLAGS =

--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -eo pipefail
+
+ORACULAR_TOP_LEVEL=$(git rev-parse --show-toplevel)
+ORACULAR_TOOLCHAIN_DIR=$ORACULAR_TOP_LEVEL/toolchain
+
+EXEC_DIR=$(pwd)
+
+if [ "$EXEC_DIR" != "$ORACULAR_TOOLCHAIN_DIR" ]; then
+    echo "script must be run from $ORACULAR_TOOLCHAIN_DIR dir."
+    exit
+fi
+
+cd gcc
+./build.sh
+
+cd ../butils
+./build.sh
+
+cd ..

--- a/toolchain/butils/build.sh
+++ b/toolchain/butils/build.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-SATURN_TOP_LEVEL=$(git rev-parse --show-toplevel)
-SATURN_BINUTILS_DIR=$SATURN_TOP_LEVEL/toolchain/butils
+set -eo pipefail
+
+ORACULAR_TOP_LEVEL=$(git rev-parse --show-toplevel)
+ORACULAR_GCC_DIR=$ORACULAR_TOP_LEVEL/toolchain/butils
 
 EXEC_DIR=$(pwd)
 
-if [ "$EXEC_DIR" != "$SATURN_BINUTILS_DIR" ]; then
+if [ "$EXEC_DIR" != "$ORACULAR_BINUTILS_DIR" ]; then
     echo 'script must be run from toolchain/butils dir.'
     exit
 fi
@@ -17,12 +19,8 @@ fi
 
 which riscv64-elf-ld > /dev/null && exit
 
-if [ "$PREFIX" = "" ]; then
-    echo "export PREFIX=\"\$HOME/opt/cross\"" >> ~/.bashrc
-    echo "export TARGET=\"riscv64-elf\"" >> ~/.bashrc
-    echo "export PATH=\"\$PREFIX/bin:\$PATH\"" >> ~/.bashrc
-    source ~/.bashrc
-fi
+PREFIX=$HOME/opt/cross
+TARGET=riscv64-elf
 
 if ! [ -d binutils-src ]; then
     mkdir -v binutils-src
@@ -41,8 +39,8 @@ mkdir -p -v binutils-build
 cd binutils-build
 
 ../binutils-src/binutils-2.36.1/configure \
-    --target=$TARGET                      \
-    --prefix=$PREFIX                      \
+    --target="$TARGET"                    \
+    --prefix="$PREFIX"                    \
     --with-sysroot                        \
     --disable-nls                         \
     --disable-werror

--- a/toolchain/butils/build.sh
+++ b/toolchain/butils/build.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 ORACULAR_TOP_LEVEL=$(git rev-parse --show-toplevel)
-ORACULAR_GCC_DIR=$ORACULAR_TOP_LEVEL/toolchain/butils
+ORACULAR_BINUTILS_DIR=$ORACULAR_TOP_LEVEL/toolchain/butils
 
 EXEC_DIR=$(pwd)
 
@@ -17,10 +17,10 @@ if [ "$1" = "clean" ]; then
     exit
 fi
 
-which riscv64-elf-ld > /dev/null && exit
-
 PREFIX=$HOME/opt/cross
 TARGET=riscv64-elf
+
+# which $TARGET-ld > /dev/null && { echo "$TARGET binutlis already installed."; exit; }
 
 if ! [ -d binutils-src ]; then
     mkdir -v binutils-src

--- a/toolchain/gcc/build.sh
+++ b/toolchain/gcc/build.sh
@@ -37,6 +37,10 @@ fi
 
 which $TARGET-as || { echo "Could not find $TARGET-as; exitting"; exit 1; }
 
+pushd gcc-src/gcc-11.1.0/
+./contrib/download_prerequisites
+popd
+
 mkdir -p -v gcc-build
 cd gcc-build
 

--- a/toolchain/gcc/build.sh
+++ b/toolchain/gcc/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eo pipefail
 
 ORACULAR_TOP_LEVEL=$(git rev-parse --show-toplevel)
 ORACULAR_GCC_DIR=$ORACULAR_TOP_LEVEL/toolchain/gcc
@@ -19,12 +19,8 @@ fi
 
 which riscv64-linux-gcc > /dev/null && exit
 
-if [ "$PREFIX" = "" ]; then
-    echo "export PREFIX=\"\$HOME/opt/cross\"" >> ~/.bashrc
-    echo "export TARGET=\"riscv64-elf\"" >> ~/.bashrc
-    echo "export PATH=\"\$PREFIX/bin:\$PATH\"" >> ~/.bashrc
-    source ~/.bashrc
-fi
+PREFIX=$HOME/opt/cross
+TARGET=riscv64-elf
 
 if ! [ -d gcc-src ]; then
     mkdir -v gcc-src
@@ -36,17 +32,17 @@ if ! [ -d gcc-src ]; then
     echo 'Extracting gcc'
     tar xf gcc-11.1.0.tar.gz
 
-    cd ../
+    cd ..
 fi
 
-which $TARGET-as || { echo 'Could not find $(TARGET)-as; exitting'; exit 1; }
+which $TARGET-as || { echo "Could not find $TARGET-as; exitting"; exit 1; }
 
 mkdir -p -v gcc-build
 cd gcc-build
 
 ../gcc-src/gcc-11.1.0/configure \
-    --target=$TARGET            \
-    --prefix=$PREFIX            \
+    --target="$TARGET"          \
+    --prefix="$PREFIX"          \
     --disable-nls               \
     --without-headers           \
     --enable-languages=c,c++


### PR DESCRIPTION
- Fix the building scripts by using internal variables instead of exporting.
- Introduce a unified script that calls `butils/build.sh` and `gcc/build.sh`.
- Use the absolute path of the toolchain in the Makefile.