### PR TITLE
Toolchain: Build in the correct order.

### DIFF
--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -12,10 +12,10 @@ if [ "$EXEC_DIR" != "$ORACULAR_TOOLCHAIN_DIR" ]; then
     exit
 fi
 
-cd gcc
+cd butils
 ./build.sh
 
-cd ../butils
+cd ../gcc
 ./build.sh
 
 cd ..

--- a/toolchain/butils/build.sh
+++ b/toolchain/butils/build.sh
@@ -43,7 +43,8 @@ cd binutils-build
     --prefix="$PREFIX"                    \
     --with-sysroot                        \
     --disable-nls                         \
-    --disable-werror
+    --disable-werror || echo "Binutils source corrupted. please remove the
+    butils/binutils-src directory and rerun the script.";
 
 make -j$(nproc)
 make install -j$(nproc)

--- a/toolchain/gcc/build.sh
+++ b/toolchain/gcc/build.sh
@@ -49,7 +49,8 @@ cd gcc-build
     --prefix="$PREFIX"          \
     --disable-nls               \
     --without-headers           \
-    --enable-languages=c,c++
+    --enable-languages=c,c++ || echo "GCC source corrupted. please remove the
+    gcc/gcc-src directory and rerun the script.";
 
 make all-gcc -j$(nproc)
 make all-target-libgcc -j$(nproc)

--- a/toolchain/gcc/build.sh
+++ b/toolchain/gcc/build.sh
@@ -27,7 +27,7 @@ if ! [ -d gcc-src ]; then
     cd gcc-src
 
     echo 'Fetching gcc version 11.1.0'
-    curl -O http://mirror.veriteknik.net.tr/gnu/gcc/gcc-11.1.0/gcc-11.1.0.tar.gz
+    curl -O https://ftp.gnu.org/gnu/gcc/gcc-11.1.0/gcc-11.1.0.tar.gz
 
     echo 'Extracting gcc'
     tar xf gcc-11.1.0.tar.gz


### PR DESCRIPTION
Binutils must be installed before GCC. Also, while at it, a more stable GCC mirror is used