### PR TITLE
Toolchain: Add the cross-bin dir to path.

### DIFF
--- a/toolchain/build.sh
+++ b/toolchain/build.sh
@@ -12,6 +12,8 @@ if [ "$EXEC_DIR" != "$ORACULAR_TOOLCHAIN_DIR" ]; then
     exit
 fi
 
+export PATH="$PATH:$HOME/opt/cross/bin"
+
 cd butils
 ./build.sh
 


### PR DESCRIPTION
This would make the subsequent scripts see the toolchain binaries.