### PR TITLE
Kernel: Enable supervisor interrupts.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,11 @@ QEMU_FLAGS += -serial mon:stdio
 QEMU_FLAGS += -nographic
 QEMU_FLAGS += -device virtio-keyboard-device
 
-KSRC_FILES = kernel/kernel.c kernel/uart.c kernel/console.c
+KSRC_FILES = kernel/kernel.c kernel/uart.c kernel/console.c kernel/trap.c
+KASM_FILES = kernel/entry.S kernel/kvec.S
 
 KOBJ_FILES = $(patsubst %.c, %.o, $(KSRC_FILES))
-KOBJ_FILES += kernel/entry.o
+KOBJ_FILES += $(patsubst %.S, %.o, $(KASM_FILES))
 
 qemu: kernel/kernel.elf
 	$(QEMU) $(QEMU_FLAGS) -kernel $<

--- a/kernel/entry.S
+++ b/kernel/entry.S
@@ -5,9 +5,10 @@
 start:
 	.cfi_startproc
 
-    /* init a stack for only one hart and then call kmain in `kernel.c`. */
+    # Initialize a stack for only one hart.
     la sp, stack_base
 
+    # Zero out the BSS section.
 	la 		a0, bss_start
 	la		a1, bss_end
 	bgeu	a0, a1, bss_init_loop_end
@@ -17,6 +18,11 @@ bss_init_loop:
 	bltu	a0, a1, bss_init_loop
     
 bss_init_loop_end:
+
+    # Only jump to `kmain` for hart #0 for now.
+    csrr    a1, mhartid
+    li      a2, 1
+    bgeu    a1, a2, halt
 
     call kmain
 

--- a/kernel/kernel.c
+++ b/kernel/kernel.c
@@ -6,6 +6,9 @@ void kmain(void) {
     uart0_init();
     puts("Oracular Spectacular\n");
 
+    void trap_init();
+    trap_init();
+
     while (1) {
         char c = read_char();
         if (c == 0x7f) {

--- a/kernel/kvec.S
+++ b/kernel/kvec.S
@@ -1,0 +1,76 @@
+.globl trap_vec
+.align 4
+trap_vec:
+        addi sp, sp, -256
+
+        sd ra, 0(sp)
+        sd sp, 8(sp)
+        sd gp, 16(sp)
+        sd tp, 24(sp)
+        sd t0, 32(sp)
+        sd t1, 40(sp)
+        sd t2, 48(sp)
+        sd s0, 56(sp)
+        sd s1, 64(sp)
+        sd a0, 72(sp)
+        sd a1, 80(sp)
+        sd a2, 88(sp)
+        sd a3, 96(sp)
+        sd a4, 104(sp)
+        sd a5, 112(sp)
+        sd a6, 120(sp)
+        sd a7, 128(sp)
+        sd s2, 136(sp)
+        sd s3, 144(sp)
+        sd s4, 152(sp)
+        sd s5, 160(sp)
+        sd s6, 168(sp)
+        sd s7, 176(sp)
+        sd s8, 184(sp)
+        sd s9, 192(sp)
+        sd s10, 200(sp)
+        sd s11, 208(sp)
+        sd t3, 216(sp)
+        sd t4, 224(sp)
+        sd t5, 232(sp)
+        sd t6, 240(sp)
+
+        # Jump to trap handler in `trap.c`
+        call ktrap
+
+        ld ra, 0(sp)
+        ld sp, 8(sp)
+        ld gp, 16(sp)
+        ld tp, 24(sp)
+        ld t0, 32(sp)
+        ld t1, 40(sp)
+        ld t2, 48(sp)
+        ld s0, 56(sp)
+        ld s1, 64(sp)
+        ld a0, 72(sp)
+        ld a1, 80(sp)
+        ld a2, 88(sp)
+        ld a3, 96(sp)
+        ld a4, 104(sp)
+        ld a5, 112(sp)
+        ld a6, 120(sp)
+        ld a7, 128(sp)
+        ld s2, 136(sp)
+        ld s3, 144(sp)
+        ld s4, 152(sp)
+        ld s5, 160(sp)
+        ld s6, 168(sp)
+        ld s7, 176(sp)
+        ld s8, 184(sp)
+        ld s9, 192(sp)
+        ld s10, 200(sp)
+        ld s11, 208(sp)
+        ld t3, 216(sp)
+        ld t4, 224(sp)
+        ld t5, 232(sp)
+        ld t6, 240(sp)
+
+        addi sp, sp, 256
+
+        # Return to the address saved on entering the trap handler.
+        sret

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -1,0 +1,14 @@
+#include <kernel/console.h>
+#include <stdint.h>
+
+extern void trap_vec();
+
+void trap_init() {
+    asm volatile("csrw stvec, %0" : : "r" ((uint64_t)trap_vec));
+}
+
+void ktrap() {
+    puts("PANIC: Inside ktrap.\n");
+    while (1)
+        ;
+}


### PR DESCRIPTION
Here the `stvec` CSR is set to `trap_vec`, which is the entry point of
all our supervisor interrupts.