### PR TITLE
CI: Add simple compilation check job.

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,0 +1,17 @@
+name: Make kernel image check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make kernel/kernel.elf

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -25,11 +25,6 @@ jobs:
         cd ${{ github.workspace }}
         cd toolchain/gcc
         ./build.sh
-    - name: build gcc
-      run: |
-        cd ${{ github.workspace }}
-        cd toolchain/gcc
-        ./build.sh
     - name: compile kernel image
       run: |
         cd ${{ github.workspace }}

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,4 @@
-name: Make kernel image check
+name: Build toolchain and make the kernel image
 
 on:
   push:
@@ -13,5 +13,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: make
-      run: make kernel/kernel.elf
+    - name: install curl
+      run: sudo apt install curl
+    - name: build binutils
+      run: |
+        cd ${{ github.workspace }}
+        cd toolchain/butils
+        ./build.sh
+    - name: build gcc
+      run: |
+        cd ${{ github.workspace }}
+        cd toolchain/gcc
+        ./build.sh
+    - name: build gcc
+      run: |
+        cd ${{ github.workspace }}
+        cd toolchain/gcc
+        ./build.sh
+    - name: compile kernel image
+      run: |
+        cd ${{ github.workspace }}
+        make kernel/kernel.elf

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,27 @@
 ARCH = riscv64
 TOOLCHAIN_PREFIX = ${HOME}/opt/cross/bin
-CC = $(TOOLCHAIN_PREFIX)/riscv64-elf-gcc
-LD = $(TOOLCHAIN_PREFIX)/riscv64-elf-ld
-AS = $(TOOLCHAIN_PREFIX)/riscv64-elf-as
+
+ifeq (, $(shell which riscv64-elf-gcc))
+	CC = $(TOOLCHAIN_PREFIX)/riscv64-elf-gcc
+	$(info Defaulting gcc path to $(CC))
+else
+	CC = riscv64-elf-gcc
+endif
+
+ifeq (, $(shell which riscv64-elf-ld))
+	LD = $(TOOLCHAIN_PREFIX)/riscv64-elf-ld
+	$(info Defaulting ld path to $(LD))
+else
+	LD = riscv64-elf-ld
+endif
+
+ifeq (, $(shell which riscv64-elf-as))
+	AS = $(TOOLCHAIN_PREFIX)/riscv64-elf-as
+	$(info Defaulting as path to $(AS))
+else
+	AS = riscv64-elf-ld
+endif
+
 QEMU = qemu-system-riscv64
 
 CFLAGS =

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,24 @@ ARCH = riscv64
 TOOLCHAIN_PREFIX = ${HOME}/opt/cross/bin
 
 ifeq (, $(shell which riscv64-elf-gcc))
-	CC = $(TOOLCHAIN_PREFIX)/riscv64-elf-gcc
-	$(info Defaulting gcc path to $(CC))
+CC = $(TOOLCHAIN_PREFIX)/riscv64-elf-gcc
+$(info Defaulting gcc path to $(CC))
 else
-	CC = riscv64-elf-gcc
+CC = riscv64-elf-gcc
 endif
 
 ifeq (, $(shell which riscv64-elf-ld))
-	LD = $(TOOLCHAIN_PREFIX)/riscv64-elf-ld
-	$(info Defaulting ld path to $(LD))
+LD = $(TOOLCHAIN_PREFIX)/riscv64-elf-ld
+$(info Defaulting ld path to $(LD))
 else
-	LD = riscv64-elf-ld
+LD = riscv64-elf-ld
 endif
 
 ifeq (, $(shell which riscv64-elf-as))
-	AS = $(TOOLCHAIN_PREFIX)/riscv64-elf-as
-	$(info Defaulting as path to $(AS))
+AS = $(TOOLCHAIN_PREFIX)/riscv64-elf-as
+$(info Defaulting as path to $(AS))
 else
-	AS = riscv64-elf-ld
+AS = riscv64-elf-as
 endif
 
 QEMU = qemu-system-riscv64
@@ -77,6 +77,7 @@ gdb: kernel/kernel.elf
 	gdb-multiarch -x .gdbinit
 
 kernel/kernel.elf: $(KOBJ_FILES)
+	echo $(KOBJ_FILES)
 	$(LD) $(LDFLAGS) $(KOBJ_FILES) -o $@
 
 %.o: %.c

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -1,4 +1,5 @@
 #include <kernel/console.h>
+#include <kernel/rv.h>
 #include <stdint.h>
 
 extern void trap_vec();

--- a/toolchain/butils/build.sh
+++ b/toolchain/butils/build.sh
@@ -20,7 +20,8 @@ fi
 PREFIX=$HOME/opt/cross
 TARGET=riscv64-elf
 
-# which $TARGET-ld > /dev/null && { echo "$TARGET binutlis already installed."; exit; }
+export PATH="$PATH:$HOME/opt/cross/bin"
+which $TARGET-ld > /dev/null && { echo "$TARGET binutlis already installed."; exit; }
 
 if ! [ -d binutils-src ]; then
     mkdir -v binutils-src

--- a/toolchain/gcc/build.sh
+++ b/toolchain/gcc/build.sh
@@ -17,6 +17,7 @@ if [ "$1" = "clean" ]; then
     exit
 fi
 
+export PATH="$PATH:$HOME/opt/cross/bin/"
 which riscv64-linux-gcc > /dev/null && exit
 
 PREFIX=$HOME/opt/cross


### PR DESCRIPTION
This is good enough for now. However, we should have a separate workflow that only compiles toolchain, and another one that uses a cached riscv toolchain to compile the kernel.